### PR TITLE
Return fmt'd error always

### DIFF
--- a/sqlc-gen-zombiezen/zombiezen/queries.qtpl
+++ b/sqlc-gen-zombiezen/zombiezen/queries.qtpl
@@ -77,7 +77,7 @@ func (ps *{%s q.Name.Pascal %}Stmt) Run(
             {%- if q.ResponseIsSingularField -%}
             return {%s q.ResponseFields[0].Name.Camel %}, fmt.Errorf("failed to execute {{.Name.Lower}} SQL: %w", err)
             {%- else -%}
-            return res, err
+            return res, fmt.Errorf("failed to execute {{.Name.Lower}} SQL: %w", err)
             {%- endif -%}
         } else if hasRow {
             {%= fillResponse(q) -%}


### PR DESCRIPTION
Having a single query like the following:

```sql
-- name: GetAuthor2 :one
SELECT * FROM authors
WHERE id = ? LIMIT 1;
```

Will generate a `Run` method similar to this:

```go
func (ps *GetAuthor2Stmt) Run(
            id int64,
) (
            res *GetAuthor2Res,
    err error,
) {
    defer ps.stmt.Reset()


    // Bind parameters
                ps.stmt.BindInt64(1, id)


    // Execute the query
        if hasRow, err := ps.stmt.Step(); err != nil {
            return res, err
        } else if hasRow {
            
....

}
```

Note that in the error case, we return `err` rather than a `fmt.Errorf` or similar. This results in generated code that imports `fmt` but doesn't use it, which breaks the build.