### PR TITLE
Simpler version of enabling foreign_keys

### DIFF
--- a/database.go
+++ b/database.go
@@ -77,13 +77,8 @@ func (db *Database) Reset(ctx context.Context, shouldClear bool) (err error) {
 	db.writePool, err = sqlitex.NewPool(uri, sqlitex.PoolOptions{
 		PoolSize: 1,
 		PrepareConn: func(conn *sqlite.Conn) error {
-			fk := conn.Prep("PRAGMA foreign_keys=on")
-			defer fk.Finalize()
-
-			if _, err := fk.Step(); err != nil {
-				return err
-			}
-			return nil
+			// Enable foreign keys. See https://sqlite.org/foreignkeys.html
+			return sqlitex.ExecuteTransient(conn, "PRAGMA foreign_keys = ON;", nil)
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
As per the example in the migrations docs: https://pkg.go.dev/zombiezen.com/go/sqlite/sqlitemigration

we can use `ExecuteTransient` as we don't need to cache the statement.