### PR TITLE
Handle 'int' columns types

### DIFF
--- a/sqlc-gen-zombiezen/zombiezen/queries.go
+++ b/sqlc-gen-zombiezen/zombiezen/queries.go
@@ -85,7 +85,7 @@ func toSQLType(c *plugin.Column) string {
 	switch toolbelt.Lower(c.Type.Name) {
 	case "text":
 		return "text"
-	case "integer":
+	case "integer", "int":
 		return "int64"
 	case "datetime", "real":
 		return "float"
@@ -117,7 +117,7 @@ func toGoType(c *plugin.Column) (val string, needsTime bool) {
 		switch typ {
 		case "text":
 			return "string", false
-		case "integer":
+		case "integer", "int":
 			return "int64", false
 		case "real":
 			return "float64", false


### PR DESCRIPTION
Having a placeholder query of:

```sql
-- name: placeholder :one 
select 1;
```

will cause the error:
```
error generating code: process: error running command panic: toGoType unhandled type int for column
```

This PR adds in the `int` type alongside the `integer` one to handle these.