### PR TITLE
Update crud.qtpl

### DIFF
--- a/sqlc-gen-zombiezen/zombiezen/crud.qtpl
+++ b/sqlc-gen-zombiezen/zombiezen/crud.qtpl
@@ -222,10 +222,10 @@ func OnceDelete{%s t.SingleName.Pascal %}(tx *sqlite.Conn, id int64) error {
 {% endfunc %}
 
 {%- func bindFields( tbl *GenerateCRUDTable) -%}
-    {%- for col, f := range tbl.Fields -%}
+    {%- for _, f := range tbl.Fields -%}
         {%- if f.IsNullable -%}
     if m.{%s f.Name.Pascal %} == nil {
-        ps.stmt.BindNull({%d col %})
+        ps.stmt.BindNull({%d f.Column %})
     } else {
         {%= bindField(f, true) -%}
     }


### PR DESCRIPTION
problem that if next field is empty, it resets prev field to nil

if m.Password == nil {
        ps.stmt.BindNull(3)
    } else {
        ps.stmt.BindText(4, *m.Password)
    }
    if m.CreatedAt == nil {
        ps.stmt.BindNull(4)
    } else {
        ps.stmt.BindFloat(5, toolbelt.TimeToJulianDay(*m.CreatedAt))
    }