### PR TITLE
fix embeddednats example

### DIFF
--- a/embeddednats/cmd/examples/main.go
+++ b/embeddednats/cmd/examples/main.go
@@ -21,8 +21,6 @@ func main() {
 	}
 
 	// behold ze server
-	ns.NatsServer.Start()
-
 	ns.WaitForServer()
 	nc, err := ns.Client()
 	if err != nil {


### PR DESCRIPTION
A minor fix for the `embeddednats` example to remove `ns.NatsServer.Start()` as it is already called by `embeddednats.New()`.